### PR TITLE
feat: 添加可拖拽的邮箱导出字段顺序配置功能

### DIFF
--- a/backend/internal/database/email_repository.go
+++ b/backend/internal/database/email_repository.go
@@ -447,32 +447,15 @@ func (r *EmailRepository) GetEmailsByIDs(userID int, emailIDs []int) ([]models.E
 	return emails, rows.Err()
 }
 
-// GetEmailsForExport 获取用于导出的邮箱数据（支持排序）
-func (r *EmailRepository) GetEmailsForExport(userID int, sortField, sortDirection string) ([]models.Email, error) {
-	// 验证排序字段
-	validSortFields := map[string]bool{
-		"email_address": true,
-		"password":      true,
-		"refresh_token": true,
-		"client_id":     true,
-		"created_at":    true,
-	}
-
-	if !validSortFields[sortField] {
-		sortField = "email_address" // 默认排序字段
-	}
-
-	// 验证排序方向
-	if sortDirection != "asc" && sortDirection != "desc" {
-		sortDirection = "asc" // 默认排序方向
-	}
-
+// GetAllEmailsByUserID 获取用户的所有邮箱（不分页，用于导出）
+func (r *EmailRepository) GetAllEmailsByUserID(userID int) ([]models.Email, error) {
 	query := `
 		SELECT id, user_id, email_address, password, client_id, refresh_token, remark,
 		       last_operation_at, created_at, updated_at
 		FROM emails
 		WHERE user_id = ?
-		ORDER BY ` + sortField + ` ` + sortDirection
+		ORDER BY created_at DESC
+	`
 
 	rows, err := r.db.Query(query, userID)
 	if err != nil {

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -121,13 +121,19 @@ type TagEmailRequest struct {
 	TagID    int   `json:"tag_id" binding:"required"`
 }
 
+// FieldOption 字段选项
+type FieldOption struct {
+	Key   string `json:"key" binding:"required"`
+	Label string `json:"label" binding:"required"`
+	Value string `json:"value" binding:"required"`
+}
+
 // ExportEmailRequest 导出邮箱请求
 type ExportEmailRequest struct {
-	Range         string `json:"range" binding:"required,oneof=all selected"`
-	Format        string `json:"format" binding:"required,oneof=txt csv"`
-	SortField     string `json:"sort_field" binding:"required"`
-	SortDirection string `json:"sort_direction" binding:"required,oneof=asc desc"`
-	EmailIDs      []int  `json:"email_ids,omitempty"`
+	Range      string        `json:"range" binding:"required,oneof=all selected"`
+	Format     string        `json:"format" binding:"required,oneof=txt csv"`
+	FieldOrder []FieldOption `json:"field_order" binding:"required,dive"`
+	EmailIDs   []int         `json:"email_ids,omitempty"`
 }
 
 // ExportEmailResponse 导出邮箱响应

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -121,6 +121,22 @@ type TagEmailRequest struct {
 	TagID    int   `json:"tag_id" binding:"required"`
 }
 
+// ExportEmailRequest 导出邮箱请求
+type ExportEmailRequest struct {
+	Range         string `json:"range" binding:"required,oneof=all selected"`
+	Format        string `json:"format" binding:"required,oneof=txt csv"`
+	SortField     string `json:"sort_field" binding:"required"`
+	SortDirection string `json:"sort_direction" binding:"required,oneof=asc desc"`
+	EmailIDs      []int  `json:"email_ids,omitempty"`
+}
+
+// ExportEmailResponse 导出邮箱响应
+type ExportEmailResponse struct {
+	Content string `json:"content"`
+	Count   int    `json:"count"`
+	Format  string `json:"format"`
+}
+
 // APIResponse 通用API响应
 type APIResponse struct {
 	Success bool        `json:"success"`

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,8 @@
         "element-plus": "^2.10.7",
         "pinia": "^3.0.3",
         "vue": "^3.5.18",
-        "vue-router": "^4.5.1"
+        "vue-router": "^4.5.1",
+        "vuedraggable": "^4.1.0"
       },
       "devDependencies": {
         "@tsconfig/node22": "^22.0.2",
@@ -5015,6 +5016,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/sortablejs": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmmirror.com/sortablejs/-/sortablejs-1.14.0.tgz",
+      "integrity": "sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmmirror.com/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5665,6 +5672,18 @@
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/vuedraggable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/vuedraggable/-/vuedraggable-4.1.0.tgz",
+      "integrity": "sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==",
+      "license": "MIT",
+      "dependencies": {
+        "sortablejs": "1.14.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.1"
       }
     },
     "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,8 @@
     "element-plus": "^2.10.7",
     "pinia": "^3.0.3",
     "vue": "^3.5.18",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "vuedraggable": "^4.1.0"
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.2",

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -128,6 +128,21 @@ export interface TagEmailRequest {
   tag_id: number
 }
 
+// 导出相关类型
+export interface ExportEmailRequest {
+  range: 'all' | 'selected'
+  format: 'txt' | 'csv'
+  sort_field: string
+  sort_direction: 'asc' | 'desc'
+  email_ids?: number[]
+}
+
+export interface ExportEmailResponse {
+  content: string
+  count: number
+  format: string
+}
+
 // 邮件相关类型
 export interface OutlookMail {
   id: string
@@ -223,7 +238,11 @@ export const emailAPI = {
   
   // 清空收件箱
   clearInbox: (id: number): Promise<AxiosResponse<APIResponse>> =>
-    api.delete(`/emails/${id}/inbox`)
+    api.delete(`/emails/${id}/inbox`),
+
+  // 导出邮箱
+  exportEmails: (data: ExportEmailRequest): Promise<AxiosResponse<APIResponse<ExportEmailResponse>>> =>
+    api.post('/emails/export', data)
 }
 
 // 标记API

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -129,11 +129,16 @@ export interface TagEmailRequest {
 }
 
 // 导出相关类型
+export interface FieldOption {
+  key: string
+  label: string
+  value: string
+}
+
 export interface ExportEmailRequest {
   range: 'all' | 'selected'
   format: 'txt' | 'csv'
-  sort_field: string
-  sort_direction: 'asc' | 'desc'
+  field_order: FieldOption[]
   email_ids?: number[]
 }
 

--- a/frontend/src/components/ExportDialog.vue
+++ b/frontend/src/components/ExportDialog.vue
@@ -35,15 +35,13 @@
             :animation="150"
             tag="div"
           >
-            <div
-              v-for="(element, index) in exportForm.fieldOrder"
-              :key="element.key"
-              class="field-item"
-            >
-              <el-icon class="drag-handle"><Rank /></el-icon>
-              <span class="field-label">{{ element.label }}</span>
-              <span class="field-position">{{ index + 1 }}</span>
-            </div>
+            <template #item="{ element, index }">
+              <div class="field-item">
+                <el-icon class="drag-handle"><Rank /></el-icon>
+                <span class="field-label">{{ element.label }}</span>
+                <span class="field-position">{{ index + 1 }}</span>
+              </div>
+            </template>
           </VueDraggable>
         </div>
       </el-form-item>

--- a/frontend/src/components/ExportDialog.vue
+++ b/frontend/src/components/ExportDialog.vue
@@ -1,0 +1,246 @@
+<template>
+  <el-dialog
+    v-model="visible"
+    title="导出邮箱数据"
+    width="580px"
+    :before-close="handleClose"
+  >
+    <el-form :model="exportForm" label-width="100px" class="export-form">
+      <!-- 导出范围 -->
+      <el-form-item label="导出范围">
+        <el-radio-group v-model="exportForm.range">
+          <el-radio label="all">全部邮箱</el-radio>
+          <el-radio label="selected" :disabled="selectedCount === 0">
+            已选择邮箱 ({{ selectedCount }}个)
+          </el-radio>
+        </el-radio-group>
+      </el-form-item>
+
+      <!-- 导出格式 -->
+      <el-form-item label="导出格式">
+        <el-radio-group v-model="exportForm.format">
+          <el-radio label="txt">TXT格式 (----分隔)</el-radio>
+          <el-radio label="csv">CSV格式 (逗号分隔)</el-radio>
+        </el-radio-group>
+      </el-form-item>
+
+      <!-- 排序字段 -->
+      <el-form-item label="排序字段">
+        <el-select v-model="exportForm.sortField" style="width: 200px">
+          <el-option label="邮箱地址" value="email_address" />
+          <el-option label="密码" value="password" />
+          <el-option label="RefreshToken" value="refresh_token" />
+          <el-option label="ClientID" value="client_id" />
+          <el-option label="添加时间" value="created_at" />
+        </el-select>
+        <el-select v-model="exportForm.sortDirection" style="width: 120px; margin-left: 10px">
+          <el-option label="升序" value="asc" />
+          <el-option label="降序" value="desc" />
+        </el-select>
+      </el-form-item>
+
+      <!-- 预览格式 -->
+      <el-form-item label="格式预览">
+        <el-input
+          type="textarea"
+          :rows="3"
+          :value="formatPreview"
+          readonly
+          class="preview-area"
+        />
+      </el-form-item>
+    </el-form>
+
+    <template #footer>
+      <div class="export-footer">
+        <el-button @click="handleClose">取消</el-button>
+        <el-button
+          type="primary"
+          @click="handleExport"
+          :loading="exporting"
+        >
+          <el-icon><Download /></el-icon>
+          导出
+        </el-button>
+      </div>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, computed, watch } from 'vue'
+import { ElMessage } from 'element-plus'
+import { Download } from '@element-plus/icons-vue'
+
+// Props
+interface Props {
+  modelValue: boolean
+  selectedCount: number
+  selectedEmailIds?: number[]
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  selectedCount: 0,
+  selectedEmailIds: () => []
+})
+
+// Emits
+interface Emits {
+  (event: 'update:modelValue', value: boolean): void
+  (event: 'export', params: ExportParams): void
+}
+
+const emit = defineEmits<Emits>()
+
+// 导出参数接口
+interface ExportParams {
+  range: 'all' | 'selected'
+  format: 'txt' | 'csv'
+  sortField: string
+  sortDirection: 'asc' | 'desc'
+  emailIds?: number[]
+}
+
+// 响应式数据
+const visible = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value)
+})
+
+const exporting = ref(false)
+
+const exportForm = reactive<ExportParams>({
+  range: 'all',
+  format: 'txt',
+  sortField: 'email_address',
+  sortDirection: 'asc'
+})
+
+// 格式预览
+const formatPreview = computed(() => {
+  const sample = {
+    email: 'example@outlook.com',
+    password: 'password123',
+    refreshToken: 'refresh_token_here',
+    clientId: 'client_id_here'
+  }
+
+  if (exportForm.format === 'txt') {
+    return `${sample.email}----${sample.password}----${sample.refreshToken}----${sample.clientId}`
+  } else {
+    return `"${sample.email}","${sample.password}","${sample.refreshToken}","${sample.clientId}"`
+  }
+})
+
+// 监听选中数量变化，自动调整导出范围
+watch(() => props.selectedCount, (newCount) => {
+  if (newCount === 0 && exportForm.range === 'selected') {
+    exportForm.range = 'all'
+  }
+})
+
+// 方法
+const handleClose = () => {
+  visible.value = false
+}
+
+const handleExport = async () => {
+  try {
+    exporting.value = true
+
+    const params: ExportParams = {
+      range: exportForm.range,
+      format: exportForm.format,
+      sortField: exportForm.sortField,
+      sortDirection: exportForm.sortDirection
+    }
+
+    // 如果导出选中的邮箱，需要传递邮箱ID列表
+    if (exportForm.range === 'selected') {
+      params.emailIds = props.selectedEmailIds
+    }
+
+    emit('export', params)
+
+    // 导出成功后关闭对话框
+    visible.value = false
+
+  } catch (error) {
+    console.error('导出失败:', error)
+    ElMessage.error('导出失败，请重试')
+  } finally {
+    exporting.value = false
+  }
+}
+
+// 重置表单
+const resetForm = () => {
+  exportForm.range = 'all'
+  exportForm.format = 'txt'
+  exportForm.sortField = 'email_address'
+  exportForm.sortDirection = 'asc'
+}
+
+// 监听对话框打开，重置表单
+watch(visible, (newVisible) => {
+  if (newVisible) {
+    resetForm()
+    // 如果有选中的邮箱，默认选择导出选中的
+    if (props.selectedCount > 0) {
+      exportForm.range = 'selected'
+    }
+  }
+})
+</script>
+
+<style scoped>
+.export-form {
+  padding: 0 20px;
+}
+
+.export-form .el-form-item {
+  margin-bottom: 20px;
+}
+
+.preview-area {
+  background-color: #f5f7fa;
+  font-family: 'Courier New', monospace;
+  font-size: 12px;
+}
+
+.preview-area :deep(.el-textarea__inner) {
+  background-color: #f5f7fa;
+  border: 1px solid #e4e7ed;
+  color: #606266;
+  font-family: 'Courier New', monospace;
+  font-size: 12px;
+}
+
+.export-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.el-radio-group .el-radio {
+  margin-right: 30px;
+}
+
+.el-form-item__label {
+  font-weight: 500;
+  color: #303133;
+}
+
+/* 响应式设计 */
+@media (max-width: 768px) {
+  .export-form {
+    padding: 0 10px;
+  }
+
+  .el-select {
+    width: 100% !important;
+    margin-left: 0 !important;
+    margin-top: 10px;
+  }
+}
+</style>

--- a/frontend/src/views/EmailsView.vue
+++ b/frontend/src/views/EmailsView.vue
@@ -342,8 +342,7 @@ const handleExport = async (params: any) => {
     const exportParams = {
       range: params.range,
       format: params.format,
-      sort_field: params.sortField,
-      sort_direction: params.sortDirection,
+      field_order: params.fieldOrder,
       email_ids: params.emailIds
     }
 


### PR DESCRIPTION
  ## ✨ 功能概述

  添加了灵活的邮箱导出功能，支持用户自定义字段顺序，提供更好的使用体验。

  ## 🚀 主要特性

  ### 📋 基础导出功能
  - **多格式支持**: TXT格式（----分隔）和CSV格式（逗号分隔）
  - **导出范围**: 支持导出全部邮箱或仅导出已选择的邮箱
  - **权限控制**: 确保用户只能导出自己的邮箱数据
  - **操作日志**: 完整的导出操作记录和审计功能

  ### 🎛️ 字段顺序配置
  - **可拖拽界面**: 用户可通过拖拽调整导出字段的顺序
  - **实时预览**: 实时显示调整后的导出格式预览
  - **位置标识**: 每个字段显示当前位置序号
  - **默认配置**: 邮箱地址 → 密码 → RefreshToken → ClientID

  ## 📝 使用方法

  1. 在邮箱列表页面点击"导出"按钮
  2. 选择导出范围（全部/已选择）和格式（TXT/CSV）
  3. 通过拖拽调整字段顺序，实时预览效果
  4. 点击导出按钮下载文件

  ---

  **Generated with ❤️ by Claude Code**